### PR TITLE
Add standard key names for KeyboardEvents

### DIFF
--- a/Controller.js
+++ b/Controller.js
@@ -15,19 +15,23 @@ function Controller() {
 Controller.prototype.onKeyDown = function(event) {
   switch (event.key) {
   case 'w':
-  case 'Up':
+  case 'ArrowUp':
+  case 'Up': // IE/Edge specific value
     this.up = true;
     break;
   case 's':
-  case 'Down':
+  case 'ArrowDown':
+  case 'Down': // IE/Edge specific value
     this.down = true;
     break;
   case 'a':
-  case 'Left':
+  case 'ArrowLeft':
+  case 'Left': // IE/Edge specific value
     this.left = true;
     break;
   case 'd':
-  case 'Right':
+  case 'ArrowRight':
+  case 'Right': // IE/Edge specific value
     this.right = true;
     break;
   }
@@ -41,19 +45,23 @@ Controller.prototype.onKeyDown = function(event) {
 Controller.prototype.onKeyUp = function(event) {
   switch (event.key) {
   case 'w':
-  case 'Up':
+  case 'ArrowUp':
+  case 'Up': // IE/Edge specific value
     this.up = false;
     break;
   case 's':
-  case 'Down':
+  case 'ArrowDown':
+  case 'Down': // IE/Edge specific value:
     this.down = false;
     break;
   case 'a':
-  case 'Left':
+  case 'ArrowLeft':
+  case 'Left': // IE/Edge specific value
     this.left = false;
     break;
   case 'd':
-  case 'Right':
+  case 'ArrowRight':
+  case 'Right': // IE/Edge specific value
     this.right = false;
     break;
   }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2018 James Hobin
+Copyright (c) 2018 Christian Paul
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Fixes #2 

This adds support for the KeyboardEvent names for the arrow keys which are not specific to IE and Edge. I tested the change only in Firefox.


Note, I also added myself to the LICENSE file.